### PR TITLE
typo fixes

### DIFF
--- a/dapr2_lectures/dapr2_01_introlm_lecture.Rmd
+++ b/dapr2_lectures/dapr2_01_introlm_lecture.Rmd
@@ -83,7 +83,7 @@ block4_name = "Advanced Topics"
 block4_lecs = c("Power Analysis",
                 "Binary Logistic Regression I",
                 "Binary Logistic Regression II",
-                "Logistic Regresison Analysis",
+                "Logistic Regression Analysis",
                 "	Exam Prep and Course Q&A")
 
 source("https://raw.githubusercontent.com/uoepsy/junk/main/R/course_table.R")

--- a/dapr2_lectures/dapr2_02_LM2.Rmd
+++ b/dapr2_lectures/dapr2_02_LM2.Rmd
@@ -85,7 +85,7 @@ block4_name = "Advanced Topics"
 block4_lecs = c("Power Analysis",
                 "Binary Logistic Regression I",
                 "Binary Logistic Regression II",
-                "Logistic Regresison Analysis",
+                "Logistic Regression Analysis",
                 "	Exam Prep and Course Q&A")
 
 source("https://raw.githubusercontent.com/uoepsy/junk/main/R/course_table.R")
@@ -671,7 +671,7 @@ $$y_i = \beta_0 + \beta_1 x_{1i} + \beta_2 x_{2i} + \beta_j x_{ji} + \epsilon_i$
 
 + Given that we have additional variables, our interpretation of the regression coefficients changes a little
 
-+ $\beta_0$ = the predicted value for $y$ **all** $x$ are 0
++ $\beta_0$ = the predicted value for $y$ when **all** $x$ are 0
 	
 + Each $\beta_j$ is now a **partial regression coefficient**
 	+ It captures the change in $y$ for a one unit change in $x$ **when all other x's are held constant**

--- a/dapr2_lectures/dapr2_03_testingbeta.Rmd
+++ b/dapr2_lectures/dapr2_03_testingbeta.Rmd
@@ -93,7 +93,7 @@ block4_name = "Advanced Topics"
 block4_lecs = c("Power Analysis",
                 "Binary Logistic Regression I",
                 "Binary Logistic Regression II",
-                "Logistic Regresison Analysis",
+                "Logistic Regression Analysis",
                 "	Exam Prep and Course Q&A")
 
 source("https://raw.githubusercontent.com/uoepsy/junk/main/R/course_table.R")

--- a/dapr2_lectures/dapr2_04_ftests.Rmd
+++ b/dapr2_lectures/dapr2_04_ftests.Rmd
@@ -89,7 +89,7 @@ block4_name = "Advanced Topics"
 block4_lecs = c("Power Analysis",
                 "Binary Logistic Regression I",
                 "Binary Logistic Regression II",
-                "Logistic Regresison Analysis",
+                "Logistic Regression Analysis",
                 "	Exam Prep and Course Q&A")
 
 source("https://raw.githubusercontent.com/uoepsy/junk/main/R/course_table.R")

--- a/dapr2_lectures/dapr2_09_BootstrapLM.Rmd
+++ b/dapr2_lectures/dapr2_09_BootstrapLM.Rmd
@@ -289,7 +289,7 @@ $$\text{SE} = \frac{\sigma}{\sqrt{n}}$$
 
 --
 
-> **Test your understanding:** In our original study, we took a sample of 35 DapR2 students and calculated their mean scores on the exam. We want to use bootstraping. What will our resample $n$ be? What will our resample statistic be? 
+> **Test your understanding:** In our original study, we took a sample of 35 DapR2 students and calculated their mean scores on the exam. We want to use bootstrapping. What will our resample $n$ be? What will our resample statistic be? 
 
 
 ---

--- a/dapr2_lectures/dapr2_11_interactions1.Rmd
+++ b/dapr2_lectures/dapr2_11_interactions1.Rmd
@@ -105,7 +105,7 @@ block4_name = "Advanced Topics"
 block4_lecs = c("Power Analysis",
                 "Binary Logistic Regression I",
                 "Binary Logistic Regression II",
-                "Logistic Regresison Analysis",
+                "Logistic Regression Analysis",
                 "	Exam Prep and Course Q&A")
 
 source("https://raw.githubusercontent.com/uoepsy/junk/main/R/course_table.R")

--- a/dapr2_lectures/dapr2_12_interactions2.Rmd
+++ b/dapr2_lectures/dapr2_12_interactions2.Rmd
@@ -105,7 +105,7 @@ block4_name = "Advanced Topics"
 block4_lecs = c("Power Analysis",
                 "Binary Logistic Regression I",
                 "Binary Logistic Regression II",
-                "Logistic Regresison Analysis",
+                "Logistic Regression Analysis",
                 "	Exam Prep and Course Q&A")
 
 source("https://raw.githubusercontent.com/uoepsy/junk/main/R/course_table.R")

--- a/dapr2_lectures/dapr2_13_interactions3.Rmd
+++ b/dapr2_lectures/dapr2_13_interactions3.Rmd
@@ -135,7 +135,7 @@ block4_name = "Advanced Topics"
 block4_lecs = c("Power Analysis",
                 "Binary Logistic Regression I",
                 "Binary Logistic Regression II",
-                "Logistic Regresison Analysis",
+                "Logistic Regression Analysis",
                 "	Exam Prep and Course Q&A")
 
 source("https://raw.githubusercontent.com/uoepsy/junk/main/R/course_table.R")

--- a/dapr2_lectures/dapr2_14_analysingexperiments.Rmd
+++ b/dapr2_lectures/dapr2_14_analysingexperiments.Rmd
@@ -104,7 +104,7 @@ block4_name = "Advanced Topics"
 block4_lecs = c("Power Analysis",
                 "Binary Logistic Regression I",
                 "Binary Logistic Regression II",
-                "Logistic Regresison Analysis",
+                "Logistic Regression Analysis",
                 "	Exam Prep and Course Q&A")
 
 source("https://raw.githubusercontent.com/uoepsy/junk/main/R/course_table.R")

--- a/dapr2_lectures/dapr2_15_InteractionAnalysis.Rmd
+++ b/dapr2_lectures/dapr2_15_InteractionAnalysis.Rmd
@@ -109,7 +109,7 @@ block4_name = "Advanced Topics"
 block4_lecs = c("Power Analysis",
                 "Binary Logistic Regression I",
                 "Binary Logistic Regression II",
-                "Logistic Regresison Analysis",
+                "Logistic Regression Analysis",
                 "	Exam Prep and Course Q&A")
 
 source("https://raw.githubusercontent.com/uoepsy/junk/main/R/course_table.R")


### PR DESCRIPTION
Again, since lectures 11, 12, 13, 14, 15 appear as fully modified, the change is just:

- In each lecture's table of contents slide: "Regresison" -> "Regression"
